### PR TITLE
Revert "Fixed the block blob not having the right major version."

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -68,8 +68,8 @@ static bool mergeBlocks(const cryptonote::block& block1, cryptonote::block& bloc
 }
 
 static bool construct_parent_block(const cryptonote::block& b, cryptonote::block& parent_block) {
-    parent_block.major_version = b.major_version;
-    parent_block.minor_version = b.minor_version;
+    parent_block.major_version = 1;
+    parent_block.minor_version = 0;
     parent_block.timestamp = b.timestamp;
     parent_block.prev_id = b.prev_id;
     parent_block.nonce = b.parent_block.nonce;


### PR DESCRIPTION
This reverts commit 4f6d35e7ae107e55db5eaf5958e1ac755b48f245.