### PR TITLE
Base fix to include windows platform specific information

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,35 +1,48 @@
 {
-    "targets": [
-        {
-            "target_name": "cryptonote",
-            "sources": [
-                "src/main.cc",
-                "src/cryptonote_core/cryptonote_format_utils.cpp",
-                "src/crypto/tree-hash.c",
-                "src/crypto/crypto.cpp",
-                "src/crypto/crypto-ops.c",
-                "src/crypto/crypto-ops-data.c",
-                "src/crypto/hash.c",
-                "src/crypto/keccak.c",
-                "src/common/base58.cpp",
-            ],
+  "targets": [
+    {
+      "target_name": "cryptonote",
+      "sources": [
+        "src/main.cc",
+        "src/cryptonote_core/cryptonote_format_utils.cpp",
+        "src/crypto/tree-hash.c",
+        "src/crypto/crypto.cpp",
+        "src/crypto/crypto-ops.c",
+        "src/crypto/crypto-ops-data.c",
+        "src/crypto/hash.c",
+        "src/crypto/keccak.c",
+        "src/common/base58.cpp"
+      ],
+      "include_dirs": [
+        "src",
+        "src/contrib/epee/include",
+        "<!(node -e \"require('nan')\")"
+      ],
+      "link_settings": {
+        "libraries": [
+          "-lboost_system",
+          "-lboost_date_time"
+        ]
+      },
+      "cflags_cc!": [
+        "-fno-exceptions",
+        "-fno-rtti"
+      ],
+      "cflags_cc": [
+        "-std=c++0x",
+        "-fexceptions",
+        "-frtti"
+      ],
+      "conditions": [
+        [
+          "OS=='win'",
+          {
             "include_dirs": [
-                "src",
-                "src/contrib/epee/include",
-                "<!(node -e \"require('nan')\")"
-            ],
-            "link_settings": {
-                "libraries": [
-                    "-lboost_system",
-                    "-lboost_date_time",
-                ]
-            },
-            "cflags_cc!": [ "-fno-exceptions", "-fno-rtti" ],
-            "cflags_cc": [
-                  "-std=c++0x",
-                  "-fexceptions",
-                  "-frtti",
-            ],
-        }
-    ]
+              "src/platform/msc"
+            ]
+          }
+        ]
+      ]
+    }
+  ]
 }

--- a/src/common/int-util.h
+++ b/src/common/int-util.h
@@ -1,6 +1,19 @@
-// Copyright (c) 2012-2013 The Cryptonote developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Bytecoin.
+//
+// Bytecoin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Bytecoin is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -3,6 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <alloca.h>
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>

--- a/src/platform/msc/alloca.h
+++ b/src/platform/msc/alloca.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Bytecoin.
+//
+// Bytecoin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Bytecoin is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#ifndef __cplusplus
+#define alloca(size) _alloca(size)
+#endif

--- a/src/platform/msc/stdbool.h
+++ b/src/platform/msc/stdbool.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Bytecoin.
+//
+// Bytecoin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Bytecoin is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#if !defined(__cplusplus)
+
+typedef int bool;
+#define true 1
+#define false 0
+
+#endif

--- a/src/platform/msc/sys/param.h
+++ b/src/platform/msc/sys/param.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Bytecoin.
+//
+// Bytecoin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Bytecoin is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Bytecoin.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#define LITTLE_ENDIAN 1234
+#define BIG_ENDIAN 4321
+#define PDP_ENDIAN 3412
+#define BYTE_ORDER LITTLE_ENDIAN


### PR DESCRIPTION
This gets us closer to having this work on windows

```
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
  main.cc
  cryptonote_format_utils.cpp
  crypto.cpp
  base58.cpp
  win_delay_load_hook.cc
d:\data\desktop\devbox\node-cryptonote-util\src\cryptonote_core\cryptonote_basic.h(7): fatal error C1083: Cannot open include file: 'boost/variant.hpp': No such file or directory (compiling source file ..\src\main.cc) [D:\Data\Desktop\devbox\node-cryptonote-util\build\cryptonote.vcxproj]
d:\data\desktop\devbox\node-cryptonote-util\src\common\util.h(9): fatal error C1083: Cannot open include file: 'boost/filesystem.hpp': No such file or directory (compiling source file ..\src\common\base58.cpp) [D:\Data\Desktop\devbox\node-cryptonote-util\build\cryptonote.vcxproj]
d:\data\desktop\devbox\node-cryptonote-util\src\contrib\epee\include\misc_log_ex.h(42): fatal error C1083: Cannot open include file: 'boost/cstdint.hpp': No such file or directory (compiling source file ..\src\cryptonote_core\cryptonote_format_utils.cpp) [D:\Data\Desktop\devbox\node-cryptonote-util\build\cryptonote.vcxproj]
```

Did I ever say how much I dislike boost :)